### PR TITLE
BAF-1136 copy filemod of overwritten file

### DIFF
--- a/pkg/helper/Helper.go
+++ b/pkg/helper/Helper.go
@@ -89,6 +89,8 @@ func SplitStringPreserveSubstrings(input string) []string {
 	return re.FindAllString(input, -1)
 }
 
+// RemoveMountDirAndPackageName removes the mount directory and package name from the given path.
+// Serves to get an absolute path in the final image context
 func RemoveMountDirAndPackageName(path string, mountDir string, packageDir string, packagePath string) string {
 	path = strings.TrimPrefix(path, mountDir)
 

--- a/pkg/helper/Helper.go
+++ b/pkg/helper/Helper.go
@@ -97,8 +97,10 @@ func RemoveMountDirAndPackageName(path string, mountDir string, packageDir strin
 	path = strings.TrimPrefix(path, packageDir)
 
 	path = strings.TrimPrefix(path, "/")
-	packageName := strings.TrimSuffix(filepath.Base(packagePath), ".zip")
-	path = strings.TrimPrefix(path, packageName)
+	if packagePath != "" {
+		packageName := strings.TrimSuffix(filepath.Base(packagePath), ".zip")
+		path = strings.TrimPrefix(path, packageName)
+	}
 
 	if path == "" {
 		path = "/"

--- a/pkg/helper/Helper_test.go
+++ b/pkg/helper/Helper_test.go
@@ -49,3 +49,15 @@ func TestRemoveMountDirAndPackageName_2(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expected, result)
 	}
 }
+
+func TestRemoveMountDirAndPackageName_3(t *testing.T) {
+	// test simulates removing path when used config package, where you do not remove package path
+	path := "/mnt/test/dir1/dir1/dirInPackage1/dirInPackage2/file.txt"
+	mountDir := "/mnt/test"
+	packageDir := "dir1/dir1"
+	expected := "/dirInPackage1/dirInPackage2/file.txt"
+	result := RemoveMountDirAndPackageName(path, mountDir, packageDir, "")
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}

--- a/pkg/image/DataCopy.go
+++ b/pkg/image/DataCopy.go
@@ -320,7 +320,7 @@ func decompressZipArchiveAndReturnService(zipReader *zip.ReadCloser, targetDir s
 func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir string, packageConfig *configuration.PackageConfig) error {
 	log.Printf("Decompressing file %s to %s", srcZipFile.Name, destFilePath)
 	// Check if the destination file already exists
-	_, err := os.Stat(destFilePath)
+	destFileInfo, err := os.Stat(destFilePath)
 	if err == nil {
 		destFilePathInPackage := helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, packageConfig.PackagePath)
 		if configuration.Config.InteractiveRun {
@@ -336,6 +336,12 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 		} else {
 			return fmt.Errorf("file %s already exists and is not marked for overwrite", destFilePathInPackage)
 		}
+	}
+	var mode os.FileMode
+	if destFileInfo != nil {
+		mode = destFileInfo.Mode()
+	} else {
+		mode = srcZipFile.Mode()
 	}
 	srcFile, err := srcZipFile.Open()
 	if err != nil {
@@ -353,7 +359,7 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 			return fmt.Errorf("unable to create symlink %s: %v", destFilePath, err)
 		}
 	} else {
-		destFile, err := os.OpenFile(destFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcZipFile.Mode())
+		destFile, err := os.OpenFile(destFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 		if err != nil {
 			return fmt.Errorf("unable to create file %s: %v", destFilePath, err)
 		}

--- a/pkg/image/DataCopy.go
+++ b/pkg/image/DataCopy.go
@@ -337,11 +337,11 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 			return fmt.Errorf("file %s already exists and is not marked for overwrite", destFilePathInPackage)
 		}
 	}
-	var mode os.FileMode
+	var fileMode os.FileMode
 	if destFileInfo != nil {
-		mode = destFileInfo.Mode()
+		fileMode = destFileInfo.Mode()
 	} else {
-		mode = srcZipFile.Mode()
+		fileMode = srcZipFile.Mode()
 	}
 	srcFile, err := srcZipFile.Open()
 	if err != nil {
@@ -359,7 +359,7 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 			return fmt.Errorf("unable to create symlink %s: %v", destFilePath, err)
 		}
 	} else {
-		destFile, err := os.OpenFile(destFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+		destFile, err := os.OpenFile(destFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
 		if err != nil {
 			return fmt.Errorf("unable to create file %s: %v", destFilePath, err)
 		}

--- a/pkg/image/DataCopy.go
+++ b/pkg/image/DataCopy.go
@@ -325,7 +325,7 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 		if packageConfig.IsStandardPackage {
 			destFilePathInPackage = helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, packageConfig.PackagePath)
 		} else {
-			// This is configuration package, where the file are not in package dir -> do not remove package nae from path
+			// This is a configuration package, where the files are not in the package dir -> do not remove the package name from the path
 			destFilePathInPackage = helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, "")
 		}
 		if configuration.Config.InteractiveRun {

--- a/pkg/image/DataCopy.go
+++ b/pkg/image/DataCopy.go
@@ -160,7 +160,6 @@ func MountPartitionAndCopyPackages(partitionNumber int, firstPartition bool) err
 			return fmt.Errorf("error while copying package: %v", err)
 		}
 	}
-	// tmpPackage := configuration.PackageConfig{EnableServices: false, ServiceNameSuffix: "", TargetDirectory: "", IsStandardPackage: false}
 	for i := range configuration.Config.ConfigurationPackages {
 		tmpPackage := configuration.PackageConfig{EnableServices: false, ServiceNameSuffix: "", TargetDirectory: "", IsStandardPackage: false}
 		tmpPackage.PackagePath = configuration.Config.ConfigurationPackages[i].PackagePath
@@ -322,7 +321,13 @@ func decompressZipFile(destFilePath string, srcZipFile *zip.File, mountDir strin
 	// Check if the destination file already exists
 	destFileInfo, err := os.Stat(destFilePath)
 	if err == nil {
-		destFilePathInPackage := helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, packageConfig.PackagePath)
+		var destFilePathInPackage string
+		if packageConfig.IsStandardPackage {
+			destFilePathInPackage = helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, packageConfig.PackagePath)
+		} else {
+			// This is configuration package, where the file are not in package dir -> do not remove package nae from path
+			destFilePathInPackage = helper.RemoveMountDirAndPackageName(destFilePath, mountDir, packageConfig.TargetDirectory, "")
+		}
 		if configuration.Config.InteractiveRun {
 			if user.GetUserConfirmation("File: " + destFilePathInPackage + " already exists. Do you want to overwrite it?") {
 				packageConfig.OverwriteFiles = append(packageConfig.OverwriteFiles, destFilePathInPackage)

--- a/tests/non_interactive_mode_integration_tests/test_app_valid_scenarios.py
+++ b/tests/non_interactive_mode_integration_tests/test_app_valid_scenarios.py
@@ -438,3 +438,56 @@ def test_15_write_multiple_different_packages(package_to_image_placer_binary):
     result = run_package_to_image_placer(package_to_image_placer_binary, config=config)
     assert result.returncode == 0
     assert inspect_image(config)
+
+def test_16_overwrote_config_package_without_overwrite(package_to_image_placer_binary):
+    "Write 2 times the same config package so it fails because the second write is duplicite"
+    config = "test_data/test_config.json"
+    img_in = "test_data/test_img.img.in"
+    img_out1 = "test_data/test_img_out.img"
+    conf_package = "test_data/configuration_package"
+    conf_package_zip = conf_package + ".zip"
+    partitions = [1]
+
+    create_test_package(conf_package, "10KB")
+    create_image(img_in, "10MB", 1)
+    make_image_mountable(img_in)
+    create_config(
+        config,
+        img_in,
+        img_out1,
+        [],
+        partitions,
+        [create_configuration_package_config(conf_package_zip)],
+    )
+
+    result = run_package_to_image_placer(package_to_image_placer_binary, config=config)
+    assert result.returncode == 0
+    assert inspect_image(config)
+
+    create_config(
+        config,
+        "",
+        img_out1,
+        [],
+        partitions,
+        [create_configuration_package_config(conf_package_zip)],
+        True
+    )
+    # try to write the same package again without overwrite flag
+    result = run_package_to_image_placer(package_to_image_placer_binary, config=config)
+    assert result.returncode == 1
+
+    # try to write the same package again with overwrite flag
+    create_config(
+        config,
+        "",
+        img_out1,
+        [],
+        partitions,
+        [create_configuration_package_config(conf_package_zip,overwrite_file=["/configuration_package/test_file","/configuration_package/symlinks/symlink"])],
+        True
+    )
+    # try to write the same package again without overwrite flag
+    result = run_package_to_image_placer(package_to_image_placer_binary, config=config)
+    assert result.returncode == 0
+    assert inspect_image(config)

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=1.1.1
+version=1.1.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing destination file permissions when decompressing zip entries and when overwriting.
  * Adjust path handling so configuration packages retain their package name while standard packages have it removed; prompts and overwrite checks reflect this.
* **Tests**
  * Added unit test for empty package-path trimming behavior.
  * Added integration test for overwriting configuration packages with and without overwrite flags.
* **Chores**
  * Bumped version from 1.1.1 to 1.1.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->